### PR TITLE
removed dylan chapp's path from default_glibc.json

### DIFF
--- a/config/default_glibc.json
+++ b/config/default_glibc.json
@@ -13,7 +13,7 @@
         { "name" : "MPI_Testsome", "freq" : 0},
         { "name" : "MPI_Testall", "freq" : 0}
     ],
-    "trace_dir" : "/p/lscratchh/chapp1/csmpi_testing/csmpi_traces/",
+    "trace_dir" : "null",
     "backtrace_impl" : "glibc",
     "trace_unmatched" : false,
     "demangle_in_place" : false,


### PR DESCRIPTION
This pull requests removes Dylan Chapp's path for the traces and sets it to null as a default. This change is useful since it makes it easier to substitute for containerization purposes.